### PR TITLE
Fix model controls and chat layout

### DIFF
--- a/login_window.py
+++ b/login_window.py
@@ -13,7 +13,8 @@ from PyQt6.QtCore import Qt, QSize
 import json
 import os
 import logging
-from main import MainApplication
+
+os.makedirs("logs", exist_ok=True)
 
 logger = logging.getLogger('DeepSeekChat.login_window')
 
@@ -104,6 +105,7 @@ class LoginWindow(QMainWindow):
             QMessageBox.critical(self, "Hata", f"Uygulama açılırken hata oluştu: {str(e)}")
 
     def open_main_app(self):
+        from main import MainApplication
         self.main_app = MainApplication()
         self.main_app.show()
         self.close()

--- a/login_window.py
+++ b/login_window.py
@@ -13,7 +13,6 @@ from PyQt6.QtCore import Qt, QSize
 import json
 import os
 import logging
-from main import MainApplication
 
 logger = logging.getLogger('DeepSeekChat.login_window')
 
@@ -104,6 +103,7 @@ class LoginWindow(QMainWindow):
             QMessageBox.critical(self, "Hata", f"Uygulama açılırken hata oluştu: {str(e)}")
 
     def open_main_app(self):
+        from main import MainApplication
         self.main_app = MainApplication()
         self.main_app.show()
         self.close()

--- a/main.py
+++ b/main.py
@@ -13,7 +13,8 @@ from PyQt6.QtWidgets import (
     QMenu, QSystemTrayIcon, QInputDialog, QDialog, QDialogButtonBox,
     QFormLayout, QTabWidget, QFileDialog, QListWidgetItem, QGroupBox,
     QScrollArea, QKeySequenceEdit, QToolButton, QSizePolicy, QGridLayout,
-    QFontComboBox, QSlider, QMessageBox, QCheckBox, QListView, QAbstractScrollArea
+    QFontComboBox, QSlider, QMessageBox, QCheckBox, QListView, QAbstractScrollArea,
+    QAbstractItemView
 )
 from PyQt6.QtCore import Qt, QTimer, QSize, QDateTime, QEvent
 from PyQt6.QtGui import (
@@ -154,8 +155,8 @@ class MainApplication(QMainWindow):
                         item = QListWidgetItem(chat["title"])
                         item.setData(Qt.ItemDataRole.UserRole, chat["id"])
                         item.setFlags(item.flags() | Qt.ItemFlag.ItemIsEditable)
-                        item.setSizeHint(QSize(25, 4))
                         self.chat_list.addItem(item)
+                        self.update_chat_title(chat["id"], chat["title"])
 
                         if "chat_data" in app_state and chat["id"] in app_state["chat_data"]:
                             self.chat_data[chat["id"]] = app_state["chat_data"][chat["id"]]
@@ -298,6 +299,8 @@ class MainApplication(QMainWindow):
         """Status bar'ı kur"""
         status_bar = self.statusBar()
         status_bar.showMessage("✅ Bağlantı kuruldu")
+        self.model_label = QLabel(f"Model: {self.model_combo.currentText()}")
+        status_bar.addPermanentWidget(self.model_label)
                   
     def setup_tray_icon(self):
         pixmap = QPixmap("icons/logo.png").scaled(
@@ -376,8 +379,10 @@ class MainApplication(QMainWindow):
         self.projects_tree.customContextMenuRequested.connect(self.show_project_context_menu)
         self.projects_tree.itemClicked.connect(self.load_project_chat)
         self.projects_tree.itemDoubleClicked.connect(self.edit_project_title)
+        self.projects_tree.setDragEnabled(True)
         self.projects_tree.setAcceptDrops(True)
         self.projects_tree.viewport().setAcceptDrops(True)
+        self.projects_tree.setDragDropMode(QAbstractItemView.DragDropMode.InternalMove)
         self.projects_tree.dragEnterEvent = self.project_drag_enter
         self.projects_tree.dropEvent = self.project_drop_event
         self.projects_tree.currentItemChanged.connect(self.load_project_context)
@@ -415,8 +420,8 @@ class MainApplication(QMainWindow):
         self.context_tabs.addTab(chat_tab, "💬 Sohbet")
         
         # Proje Bağlamı Sekmesi
-        project_tab = QWidget()
-        project_layout = QVBoxLayout(project_tab)
+        self.project_context_tab = QWidget()
+        project_layout = QVBoxLayout(self.project_context_tab)
         self.project_instructions = QTextEdit()
         self.project_instructions.setPlaceholderText("Proje talimatları...")
         project_layout.addWidget(QLabel("📝 Talimatlar:"))
@@ -432,7 +437,7 @@ class MainApplication(QMainWindow):
         file_btn_layout.addWidget(self.add_project_file_btn)
         file_btn_layout.addWidget(self.remove_project_file_btn)
         project_layout.addLayout(file_btn_layout)
-        self.context_tabs.addTab(project_tab, "📂 Proje Bağlamı")
+        self.context_tabs.addTab(self.project_context_tab, "📂 Proje Bağlamı")
                 
         # Mesaj Gönderme Paneli
         send_panel = QWidget()
@@ -939,7 +944,8 @@ class MainApplication(QMainWindow):
             # Aktif modeli göster
             model_name = self.model_combo.currentText()
             self.statusBar().showMessage(f"🤖 Aktif Model: {model_name}", 5000)
-        
+            self.hide_project_panels()
+
         except Exception as e:
             logger.error(f"Sohbet yüklenirken hata: {str(e)}")
     
@@ -978,7 +984,8 @@ class MainApplication(QMainWindow):
                 # Aktif modeli göster
                 model_name = self.model_combo.currentText()
                 self.statusBar().showMessage(f"🤖 Aktif Model: {model_name}", 5000)
-        
+                self.show_project_panels()
+
         except Exception as e:
             logger.error(f"Proje sohbeti yüklenirken hata: {str(e)}")
             
@@ -1053,7 +1060,7 @@ class MainApplication(QMainWindow):
             
             # Yeni sohbet öğesi oluştur
             chat_count = self.chat_list.count() + 1
-            chat_name = f"Yeni Sohbet {chat_count}"
+            chat_name = self.ensure_unique_chat_title(f"Yeni Sohbet {chat_count}")
             chat_id = str(uuid.uuid4())
             item = QListWidgetItem(chat_name)
             item.setData(Qt.ItemDataRole.UserRole, chat_id)
@@ -1160,8 +1167,35 @@ class MainApplication(QMainWindow):
         """Başlık değiştiğinde güncellemeleri yap"""
         chat_id = item.data(Qt.ItemDataRole.UserRole)
         if chat_id in self.chat_data:
-            new_title = item.text()
-            self.update_chat_title(chat_id, new_title)            
+            new_title = self.ensure_unique_chat_title(item.text(), chat_id)
+            self.update_chat_title(chat_id, new_title)
+
+    def ensure_unique_chat_title(self, title, exclude_id=None):
+        """Aynı isimde sohbet oluşmasını engeller"""
+        existing = [data["title"] for cid, data in self.chat_data.items() if cid != exclude_id]
+        if title not in existing:
+            return title
+        base = title
+        suffix = 1
+        new_title = f"{base} {suffix}"
+        while new_title in existing:
+            suffix += 1
+            new_title = f"{base} {suffix}"
+        return new_title
+
+    def show_project_panels(self):
+        if self.context_tabs.indexOf(self.project_view) == -1:
+            self.context_tabs.insertTab(0, self.project_view, "📂 Proje")
+        if self.context_tabs.indexOf(self.project_context_tab) == -1:
+            self.context_tabs.addTab(self.project_context_tab, "📂 Proje Bağlamı")
+
+    def hide_project_panels(self):
+        idx = self.context_tabs.indexOf(self.project_view)
+        if idx != -1:
+            self.context_tabs.removeTab(idx)
+        idx = self.context_tabs.indexOf(self.project_context_tab)
+        if idx != -1:
+            self.context_tabs.removeTab(idx)
             
     def _expand_editor_widget(self):
         """Edit kutusunu genişletir"""
@@ -1440,7 +1474,7 @@ class MainApplication(QMainWindow):
         """Projeye yeni sohbet ekle"""
         try:
             chat_count = project_item.childCount() + 1
-            chat_name = f"Yeni Sohbet {chat_count}"
+            chat_name = self.ensure_unique_chat_title(f"Yeni Sohbet {chat_count}")
             chat_id = str(uuid.uuid4())
             new_chat = QTreeWidgetItem([f"💬 {chat_name}"])
             new_chat.setData(0, Qt.ItemDataRole.UserRole, chat_id)
@@ -1524,9 +1558,23 @@ class MainApplication(QMainWindow):
                 json.dump({"api_key": api_key}, f)
             self.api_key = api_key
             self.statusBar().showMessage("🔑 API anahtarı kaydedildi", 3000)
-        
+
         except Exception as e:
             logger.error(f"API anahtarı kaydedilirken hata: {str(e)}")
+
+    def save_model_settings(self):
+        """Model yönetimi diyalogundan gelen ayarları kaydet"""
+        try:
+            key = self.api_key_edit.text().strip()
+            if key:
+                self.save_api_key(key)
+            selected = self.model_combo_dialog.currentText()
+            self.model_combo.setCurrentText(selected)
+            if hasattr(self, "model_dialog"):
+                self.model_dialog.accept()
+            self.statusBar().showMessage("✅ Model ayarları kaydedildi", 3000)
+        except Exception as e:
+            logger.error(f"Model ayarları kaydedilirken hata: {str(e)}")
     
     def get_response_from_openrouter(self, model_name):
         """OpenRouter API'sinden yanıt al"""
@@ -1613,27 +1661,27 @@ class MainApplication(QMainWindow):
             # Aktif modeli al
             model_name = self.model_combo.currentText()
             
-            # API iş parçacığı
-            self.worker = WorkerThread(
-                api_key="demo-key",
-                conversation_history=[{"role": msg['sender'], "content": msg['message']} for msg in self.chat_data[self.active_chat_id]["messages"]],
-                model=model_name
-            )
+            history = [{"role": ("user" if m["sender"] == "user" else "assistant"), "content": m["message"]}
+                       for m in self.chat_data[self.active_chat_id]["messages"]]
+
+            if self.api_key:
+                self.worker = WorkerThread(
+                    self.api_key,
+                    history,
+                    self.model_mapping.get(model_name, "deepseek/deepseek-r1:free")
+                )
+            else:
+                self.worker = WorkerThread(
+                    "demo-key",
+                    history,
+                    model_name
+                )
             self.worker.thinking_updated.connect(self.handle_thinking_update)
             self.worker.response_received.connect(lambda reply, t: self.handle_api_response(reply, model_name))
             self.worker.error_occurred.connect(lambda err: self.statusBar().showMessage(err, 5000))
             self.worker.start()
             self.statusBar().showMessage("⏳ DeepSeek yanıt oluşturuyor...")
-            if self.api_key:
-                history = []
-                for msg in self.chat_data[self.active_chat_id]["messages"]:
-                    role = "user" if msg["sender"] == "user" else "assistant"
-                    history.append({"role": role, "content": msg["message"]})
-                self.worker = WorkerThread(self.api_key, history, self.model_mapping.get(model_name, "deepseek/deepseek-r1:free"))
-                self.worker.response_received.connect(lambda reply, _: self.handle_api_response(reply, model_name))
-                self.worker.error_occurred.connect(lambda err: self.handle_api_error(err, model_name))
-                self.worker.start()
-            else:
+            if not self.api_key:
                 QTimer.singleShot(1500, lambda: self.simulate_response(model_name))
             
             # Ekli dosyaları temizle
@@ -1648,6 +1696,8 @@ class MainApplication(QMainWindow):
     def model_changed(self, index):
         model_name = self.model_combo.currentText()
         self.statusBar().showMessage(f"🤖 Aktif model: {model_name}", 5000)
+        if hasattr(self, "model_label"):
+            self.model_label.setText(f"Model: {model_name}")
         if "coder" in model_name:
             self.message_input.setPlaceholderText("Kod problemini yazın...")
         elif "math" in model_name:
@@ -1673,7 +1723,7 @@ class MainApplication(QMainWindow):
                 f"<span class='sender'>{prefix}</span>"
                 f"<div class='message-text'>{message}</div>"
                 "</div>"
-            )
+            ) + "<br/>"
 
             self.chat_display.insertHtml(html_content)
             self.chat_display.ensureCursorVisible()

--- a/main.py
+++ b/main.py
@@ -117,6 +117,7 @@ class MainApplication(QMainWindow):
         
         # Uygulama durumunu yükle
         self.load_app_state()
+        self.update_model_combo()
         self.apply_font_settings()
         
         # Tema
@@ -127,7 +128,12 @@ class MainApplication(QMainWindow):
         self.api_key = None
         self.api_base_url = "https://openrouter.ai/api/v1"
         self.load_api_key()
-        
+
+    def update_model_combo(self):
+        """Update model label according to combo box"""
+        if hasattr(self, "model_label"):
+            self.model_label.setText(f"Model: {self.model_combo.currentText()}")
+
     # BU METODU EKLEYİN (init'den sonra herhangi bir yere)
     def apply_font_settings(self):
         """Font ayarlarını uygular"""
@@ -1570,6 +1576,7 @@ class MainApplication(QMainWindow):
                 self.save_api_key(key)
             selected = self.model_combo_dialog.currentText()
             self.model_combo.setCurrentText(selected)
+            self.update_model_combo()
             if hasattr(self, "model_dialog"):
                 self.model_dialog.accept()
             self.statusBar().showMessage("✅ Model ayarları kaydedildi", 3000)
@@ -1696,8 +1703,7 @@ class MainApplication(QMainWindow):
     def model_changed(self, index):
         model_name = self.model_combo.currentText()
         self.statusBar().showMessage(f"🤖 Aktif model: {model_name}", 5000)
-        if hasattr(self, "model_label"):
-            self.model_label.setText(f"Model: {model_name}")
+        self.update_model_combo()
         if "coder" in model_name:
             self.message_input.setPlaceholderText("Kod problemini yazın...")
         elif "math" in model_name:

--- a/main.py
+++ b/main.py
@@ -21,7 +21,6 @@ from PyQt6.QtGui import (
     QAction, QIcon, QKeySequence, QTextCursor, QColor, QTextCharFormat, QFont, QPixmap, QFontMetrics
 )
 
-from login_window import LoginWindow
 from user_manager import UserManager
 from worker_thread import WorkerThread
 from project_view import ProjectView
@@ -30,8 +29,9 @@ from utils.font_manager import apply_font_settings
 from utils import validate_email, format_file_size, create_safe_filename
 
 # Loglama sistemini başlat
+os.makedirs("logs", exist_ok=True)
 logging.basicConfig(
-    filename='app.log',
+    filename=os.path.join("logs", "app.log"),
     level=logging.DEBUG,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
@@ -1821,9 +1821,11 @@ if __name__ == "__main__":
         
         # Pencereyi belirle
         window = None
-        
+
         user_manager = UserManager()
-        
+
+        from login_window import LoginWindow
+
          # Giriş bilgilerini kontrol et
         if os.path.exists("user_prefs.json"):
             with open("user_prefs.json", "r") as f:

--- a/styles/base.css
+++ b/styles/base.css
@@ -51,3 +51,9 @@ QMessageBox QPushButton {
     color: #ffffff;
     border: 1px solid #1d4a7a;
 }
+
+QPushButton#attach_btn:hover,
+QPushButton#send_btn:hover {
+    background-color: #4a76cd;
+    color: white;
+}

--- a/styles/chat_message.css
+++ b/styles/chat_message.css
@@ -10,5 +10,5 @@
 }
 
 .chat-message .message-text {
-    margin-top: 5px;
+    margin-left: 4px;
 }

--- a/styles/dark_theme.css
+++ b/styles/dark_theme.css
@@ -175,12 +175,13 @@ QPushButton#btn_theme_purple:hover {
 }
 
 /* Sohbet mesajları */
+
 .chat-message.user-message {
     background-color: #1e1e1e;
-    color: #4ec9b0;
+    color: #4a76cd;
 }
 
 .chat-message.assistant-message {
     background-color: #2a2a2a;
-    color: #d69a66;
+    color: #cccccc;
 }

--- a/styles/deep_thought_btn.css
+++ b/styles/deep_thought_btn.css
@@ -1,4 +1,8 @@
 QPushButton#deep_thought_btn {
+    background-color: #3a3a3a;
+    color: #ffffff;
+}
+QPushButton#deep_thought_btn:checked {
     background-color: #4a76cd;
     color: white;
 }

--- a/styles/green_theme.css
+++ b/styles/green_theme.css
@@ -157,10 +157,10 @@ QPushButton#btn_theme_purple:hover {
 /* Sohbet mesajları */
 .chat-message.user-message {
     background-color: #1c3626;
-    color: #4ec9b0;
+    color: #4a76cd;
 }
 
 .chat-message.assistant-message {
     background-color: #284f36;
-    color: #d69a66;
+    color: #cccccc;
 }

--- a/styles/light_theme.css
+++ b/styles/light_theme.css
@@ -171,10 +171,10 @@ QPushButton#btn_theme_purple:hover {
 /* Sohbet mesajları */
 .chat-message.user-message {
     background-color: #f0f4f9;
-    color: #4ec9b0;
+    color: #4a76cd;
 }
 
 .chat-message.assistant-message {
     background-color: #ffffff;
-    color: #d69a66;
+    color: #666666;
 }

--- a/styles/purple_theme.css
+++ b/styles/purple_theme.css
@@ -157,10 +157,10 @@ QPushButton#btn_theme_purple:hover {
 /* Sohbet mesajları */
 .chat-message.user-message {
     background-color: #302049;
-    color: #4ec9b0;
+    color: #4a76cd;
 }
 
 .chat-message.assistant-message {
     background-color: #473068;
-    color: #d69a66;
+    color: #cccccc;
 }

--- a/styles/web_search_btn.css
+++ b/styles/web_search_btn.css
@@ -1,4 +1,8 @@
 QPushButton#web_search_btn {
+    background-color: #3a3a3a;
+    color: #ffffff;
+}
+QPushButton#web_search_btn:checked {
     background-color: #4a76cd;
     color: white;
 }


### PR DESCRIPTION
## Summary
- restore model management by adding `save_model_settings`
- show the selected model in the status bar
- ensure chat names are unique and update correctly
- allow showing/hiding project panels based on selection
- fix message spacing and loading issues
- clean up model worker creation

## Testing
- `python -m py_compile main.py project_view.py worker_thread.py utils/helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_6870fb89e3348329b36bafe619e2974d